### PR TITLE
Add New/Reset button to reset all form fields

### DIFF
--- a/index.html
+++ b/index.html
@@ -640,6 +640,40 @@
       display: none;
     }
 
+    /* Button Group */
+    .button-group {
+      display: flex;
+      gap: 12px;
+    }
+
+    .button-group .generate-btn {
+      flex: 1;
+    }
+
+    /* Reset Button */
+    .reset-btn {
+      display: block;
+      padding: 16px 24px;
+      background: transparent;
+      border: 2px solid var(--color-border);
+      border-radius: 8px;
+      color: var(--color-text-muted);
+      font-weight: 600;
+      font-size: 16px;
+      cursor: pointer;
+      transition: all 0.2s ease;
+    }
+
+    .reset-btn:hover {
+      border-color: var(--color-accent);
+      color: var(--color-accent);
+      transform: translateY(-2px);
+    }
+
+    .reset-btn:active {
+      transform: translateY(0);
+    }
+
     input:invalid {
       border-color: var(--color-error);
       box-shadow: 0 0 0 3px rgba(239, 68, 68, 0.1);

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,5 +1,5 @@
 // src/main.ts
-import { createForm, getFormValues, isFormValid } from './ui'
+import { createForm, getFormValues, isFormValid, resetForm } from './ui'
 import { calculateToolpath } from './toolpath'
 import { generateGCode } from './gcode'
 import { generatePreviewSVG } from './preview'
@@ -15,7 +15,10 @@ function init() {
       <div id="form-container"></div>
       <div class="preview-container">
         <div id="preview"></div>
-        <button class="generate-btn" id="generateBtn" disabled>Generate GCode</button>
+        <div class="button-group">
+          <button class="reset-btn" id="resetBtn">New</button>
+          <button class="generate-btn" id="generateBtn" disabled>Generate GCode</button>
+        </div>
       </div>
     </div>
   `
@@ -23,6 +26,7 @@ function init() {
   const formContainer = app.querySelector('#form-container')!
   const previewContainer = app.querySelector('#preview')!
   const generateBtn = app.querySelector('#generateBtn') as HTMLButtonElement
+  const resetBtn = app.querySelector('#resetBtn') as HTMLButtonElement
 
   let currentParams: Partial<SurfacingParams> = {}
 
@@ -62,6 +66,13 @@ function init() {
     a.download = `rastermaster-${params.stockWidth}x${params.stockHeight}.gcode`
     a.click()
     URL.revokeObjectURL(url)
+  })
+
+  resetBtn.addEventListener('click', () => {
+    resetForm(form, (params) => {
+      currentParams = params
+      updatePreview()
+    })
   })
 
   // Initial preview

--- a/src/ui.ts
+++ b/src/ui.ts
@@ -241,6 +241,48 @@ export function isFormValid(params: Partial<SurfacingParams>): boolean {
     params.stockHeight && params.stockHeight > 0)
 }
 
+export function resetForm(form: HTMLElement, onUpdate: (params: Partial<SurfacingParams>) => void): void {
+  const setValue = (id: string, value: string) => {
+    const input = form.querySelector(`#${id}`) as HTMLInputElement
+    if (input) input.value = value
+  }
+
+  const setChecked = (id: string, checked: boolean) => {
+    const input = form.querySelector(`#${id}`) as HTMLInputElement
+    if (input) input.checked = checked
+  }
+
+  const setRadio = (name: string, value: string) => {
+    const input = form.querySelector(`input[name="${name}"][value="${value}"]`) as HTMLInputElement
+    if (input) input.checked = true
+  }
+
+  // Clear stock dimensions (no defaults for these)
+  setValue('stockWidth', '')
+  setValue('stockHeight', '')
+
+  // Reset all other fields to defaults
+  setValue('fudgeFactor', DEFAULT_PARAMS.fudgeFactor.toString())
+  setValue('bitDiameter', DEFAULT_PARAMS.bitDiameter.toString())
+  setValue('stepoverPercent', DEFAULT_PARAMS.stepoverPercent.toString())
+  setValue('numPasses', DEFAULT_PARAMS.numPasses.toString())
+  setValue('depthPerPass', DEFAULT_PARAMS.depthPerPass.toString())
+  setValue('pauseInterval', DEFAULT_PARAMS.pauseInterval.toString())
+  setValue('feedRate', DEFAULT_PARAMS.feedRate.toString())
+  setValue('plungeRate', DEFAULT_PARAMS.plungeRate.toString())
+  setValue('spindleRpm', DEFAULT_PARAMS.spindleRpm.toString())
+  setValue('retractHeight', DEFAULT_PARAMS.retractHeight.toString())
+
+  setRadio('rasterDirection', DEFAULT_PARAMS.rasterDirection)
+  setChecked('skimPass', DEFAULT_PARAMS.skimPass)
+
+  // Note: We do NOT re-hide the Job/Tool columns - animation should not repeat
+  // The columns stay visible after first reveal
+
+  // Trigger update
+  onUpdate(getFormValues(form))
+}
+
 export function validateParams(params: Partial<SurfacingParams>): string[] {
   const errors: string[] = []
 


### PR DESCRIPTION
Adds a "New" button next to the Generate GCode button that resets all
form fields to their default values. The Job and Tool sections stay
visible (animation does not repeat) per the original spec.

https://claude.ai/code/session_013Ta9MXvpu2PELd5tt39Qi4