### PR TITLE
Retract between passes and fix preamble Z-descent order

### DIFF
--- a/src/gcode.test.ts
+++ b/src/gcode.test.ts
@@ -23,9 +23,9 @@ function verifySnakingPattern(
   const finalRetractIdx = lines.findIndex(l => l.includes('Final retract'))
   const passLines = lines.slice(firstPlungeIdx, finalRetractIdx)
 
-  // Count retracts in the pass (should be 0)
+  // Count retracts in the pass (should be 1 - only at the end of the pass)
   const retractCount = passLines.filter(l => l.includes('G0 Z')).length
-  expect(retractCount).toBe(0)
+  expect(retractCount).toBe(1)
 
   // Verify stepover moves use G1 (feed rate)
   const stepoverLines = passLines.filter(l => l.includes('Stepover'))
@@ -79,6 +79,24 @@ describe('generateGCode', () => {
     expect(gcode).toContain('G90')
     expect(gcode).toContain('G20')
     expect(gcode).toContain('M3 S18000')
+  })
+
+  test('preamble travels XY to start before descending Z', () => {
+    const params = mergeWithDefaults({
+      stockWidth: 10,
+      stockHeight: 5,
+      retractHeight: 0.125,
+    })
+    const toolpath = calculateToolpath(params)
+    const gcode = generateGCode(toolpath)
+    const lines = gcode.split('\n')
+
+    const xyMoveIdx = lines.findIndex(l => l.includes('Move to start'))
+    const zDescentIdx = lines.findIndex(l => l.includes('Rapid to retract height'))
+
+    expect(xyMoveIdx).toBeGreaterThan(-1)
+    expect(zDescentIdx).toBeGreaterThan(-1)
+    expect(xyMoveIdx).toBeLessThan(zDescentIdx)
   })
 
   test('generates correct postamble', () => {
@@ -163,5 +181,62 @@ describe('generateGCode', () => {
     const gcode = generateGCode(toolpath)
 
     verifySnakingPattern(gcode, 'y')
+  })
+
+  test('retracts to safe height at end of each pass before repositioning', () => {
+    const params = mergeWithDefaults({
+      stockWidth: 2,
+      stockHeight: 2,
+      bitDiameter: 1,
+      stepoverPercent: 50,
+      rasterDirection: 'x',
+      retractHeight: 0.125,
+      skimPass: false,
+      totalDepth: 0.02,
+      depthPerPass: 0.01,
+    })
+    const toolpath = calculateToolpath(params)
+    const gcode = generateGCode(toolpath)
+    const lines = gcode.split('\n')
+
+    const plungeIndices = lines.reduce<number[]>((acc, line, i) => {
+      if (line.includes('G1 Z-') && line.includes('Plunge')) acc.push(i)
+      return acc
+    }, [])
+
+    expect(plungeIndices.length).toBe(2)
+
+    // Between pass 1's plunge and pass 2's plunge there must be a retract
+    const betweenPasses = lines.slice(plungeIndices[0], plungeIndices[1])
+    const retracts = betweenPasses.filter(l => /^G0 Z/.test(l))
+    expect(retracts.length).toBe(1)
+    expect(retracts[0]).toContain('0.125')
+  })
+
+  test('repositions with a single diagonal G0 XY command between passes', () => {
+    const params = mergeWithDefaults({
+      stockWidth: 2,
+      stockHeight: 2,
+      bitDiameter: 1,
+      stepoverPercent: 50,
+      rasterDirection: 'x',
+      retractHeight: 0.125,
+      skimPass: false,
+      totalDepth: 0.02,
+      depthPerPass: 0.01,
+    })
+    const toolpath = calculateToolpath(params)
+    const gcode = generateGCode(toolpath)
+    const lines = gcode.split('\n')
+
+    const plungeIndices = lines.reduce<number[]>((acc, line, i) => {
+      if (line.includes('G1 Z-') && line.includes('Plunge')) acc.push(i)
+      return acc
+    }, [])
+
+    // The rapid immediately before the second plunge must contain both X and Y (diagonal move)
+    const lineBeforePlunge2 = lines[plungeIndices[1] - 1]
+    expect(lineBeforePlunge2).toMatch(/^G0 X/)
+    expect(lineBeforePlunge2).toContain('Y')
   })
 })

--- a/src/gcode.ts
+++ b/src/gcode.ts
@@ -14,9 +14,8 @@ export function generateGCode(toolpath: Toolpath): string {
   lines.push('G90 ; Absolute positioning')
   lines.push('G20 ; Inches')
   lines.push(`M3 S${params.spindleRpm} ; Spindle on`)
-  lines.push(`G0 Z${fmt(params.retractHeight)} ; Retract to safe Z`)
 
-  // Move to start position
+  // Move XY to start first (at current Z), then descend to retract height
   const firstLine = toolpath.passes[0]?.lines[0]
   const startX = params.rasterDirection === 'x'
     ? (firstLine?.xStart ?? toolpath.bounds.xMin)
@@ -25,6 +24,7 @@ export function generateGCode(toolpath: Toolpath): string {
     ? (firstLine?.y ?? toolpath.bounds.yMin)
     : (firstLine?.yStart ?? toolpath.bounds.yMin)
   lines.push(`G0 X${fmt(startX)} Y${fmt(startY)} ; Move to start`)
+  lines.push(`G0 Z${fmt(params.retractHeight)} ; Rapid to retract height`)
   lines.push('')
 
   // Generate passes
@@ -74,9 +74,8 @@ function generatePass(pass: ZPass, retractHeight: number, feedRate: number, plun
     if (direction === 'x') {
       // X-axis raster
       if (lineIndex === 0) {
-        // First line: rapid to start, plunge, cut
-        lines.push(`G0 Y${fmt(line.y!)}`)
-        lines.push(`G0 X${fmt(line.xStart!)}`)
+        // First line: diagonal rapid to start, plunge, cut
+        lines.push(`G0 X${fmt(line.xStart!)} Y${fmt(line.y!)} ; Rapid to start`)
         lines.push(`G1 Z${fmt(pass.z)} F${plungeRate} ; Plunge`)
         lines.push(`G1 X${fmt(line.xEnd!)} F${feedRate} ; Cut`)
       } else {
@@ -87,9 +86,8 @@ function generatePass(pass: ZPass, retractHeight: number, feedRate: number, plun
     } else {
       // Y-axis raster
       if (lineIndex === 0) {
-        // First line: rapid to start, plunge, cut
-        lines.push(`G0 X${fmt(line.x!)}`)
-        lines.push(`G0 Y${fmt(line.yStart!)}`)
+        // First line: diagonal rapid to start, plunge, cut
+        lines.push(`G0 X${fmt(line.x!)} Y${fmt(line.yStart!)} ; Rapid to start`)
         lines.push(`G1 Z${fmt(pass.z)} F${plungeRate} ; Plunge`)
         lines.push(`G1 Y${fmt(line.yEnd!)} F${feedRate} ; Cut`)
       } else {
@@ -99,6 +97,8 @@ function generatePass(pass: ZPass, retractHeight: number, feedRate: number, plun
       }
     }
   })
+
+  lines.push(`G0 Z${fmt(retractHeight)} ; Retract`)
 
   return lines
 }


### PR DESCRIPTION
Closes #5, closes #6

Two safety fixes discovered during a real surfacing job on the Shapeoko.

**Between-pass retract:** After finishing the last raster line of a pass, the machine was moving back to the start position at full cut depth, potentially crashing into fixtures. Each pass now ends with `G0 Z<retractHeight>` before any repositioning, and the XY move to the next pass start is a single diagonal rapid (combined X and Y) rather than two separate L-shaped moves.

**Preamble Z-descent order:** On job start the machine was dropping Z to retract height from wherever it was parked before traveling to the job start corner. Alarming to watch and inconsistent with standard CNC practice. The preamble now travels XY to the start position first (at whatever safe Z the operator jogged to), then rapids down to retract height, then feed-plunges to cut depth.