### PR TITLE
feat: fractional inch input (10 5/8, 1/4, etc.)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -6,7 +6,7 @@
       "name": "surfacer",
       "devDependencies": {
         "@types/bun": "latest",
-        "happy-dom": "^20.3.9",
+        "happy-dom": "^20.9.0",
         "vite": "^7.3.1",
         "vite-plugin-singlefile": "^2.3.0",
       },
@@ -132,7 +132,7 @@
 
     "bun-types": ["bun-types@1.3.6", "", { "dependencies": { "@types/node": "*" } }, "sha512-OlFwHcnNV99r//9v5IIOgQ9Uk37gZqrNMCcqEaExdkVq3Avwqok1bJFmvGMCkCE0FqzdY8VMOZpfpR3lwI+CsQ=="],
 
-    "entities": ["entities@4.5.0", "", {}, "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw=="],
+    "entities": ["entities@7.0.1", "", {}, "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA=="],
 
     "esbuild": ["esbuild@0.27.2", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.27.2", "@esbuild/android-arm": "0.27.2", "@esbuild/android-arm64": "0.27.2", "@esbuild/android-x64": "0.27.2", "@esbuild/darwin-arm64": "0.27.2", "@esbuild/darwin-x64": "0.27.2", "@esbuild/freebsd-arm64": "0.27.2", "@esbuild/freebsd-x64": "0.27.2", "@esbuild/linux-arm": "0.27.2", "@esbuild/linux-arm64": "0.27.2", "@esbuild/linux-ia32": "0.27.2", "@esbuild/linux-loong64": "0.27.2", "@esbuild/linux-mips64el": "0.27.2", "@esbuild/linux-ppc64": "0.27.2", "@esbuild/linux-riscv64": "0.27.2", "@esbuild/linux-s390x": "0.27.2", "@esbuild/linux-x64": "0.27.2", "@esbuild/netbsd-arm64": "0.27.2", "@esbuild/netbsd-x64": "0.27.2", "@esbuild/openbsd-arm64": "0.27.2", "@esbuild/openbsd-x64": "0.27.2", "@esbuild/openharmony-arm64": "0.27.2", "@esbuild/sunos-x64": "0.27.2", "@esbuild/win32-arm64": "0.27.2", "@esbuild/win32-ia32": "0.27.2", "@esbuild/win32-x64": "0.27.2" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-HyNQImnsOC7X9PMNaCIeAm4ISCQXs5a5YasTXVliKv4uuBo1dKrG0A+uQS8M5eXjVMnLg3WgXaKvprHlFJQffw=="],
 
@@ -142,7 +142,7 @@
 
     "fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
 
-    "happy-dom": ["happy-dom@20.3.9", "", { "dependencies": { "@types/node": ">=20.0.0", "@types/whatwg-mimetype": "^3.0.2", "@types/ws": "^8.18.1", "entities": "^4.5.0", "whatwg-mimetype": "^3.0.0", "ws": "^8.18.3" } }, "sha512-OIoj0PcK2JaxQuANHxWkxFRSNXAuSgO1vCzCT66KItE0W/ieZLG+/iW8OetlxB+F9EaPB7DoFYKAubFG1f4Mvw=="],
+    "happy-dom": ["happy-dom@20.9.0", "", { "dependencies": { "@types/node": ">=20.0.0", "@types/whatwg-mimetype": "^3.0.2", "@types/ws": "^8.18.1", "entities": "^7.0.1", "whatwg-mimetype": "^3.0.0", "ws": "^8.18.3" } }, "sha512-GZZ9mKe8r646NUAf/zemnGbjYh4Bt8/MqASJY+pSm5ZDtc3YQox+4gsLI7yi1hba6o+eCsGxpHn5+iEVn31/FQ=="],
 
     "is-number": ["is-number@7.0.0", "", {}, "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng=="],
 

--- a/index.html
+++ b/index.html
@@ -463,6 +463,18 @@
       margin-bottom: 0;
     }
 
+    .input-stack {
+      display: flex;
+      flex-direction: column;
+      gap: 2px;
+    }
+
+    .resolved-value {
+      font-size: 11px;
+      color: var(--color-text-muted);
+      display: none;
+    }
+
     label {
       font-size: 13px;
       font-weight: 500;

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   },
   "devDependencies": {
     "@types/bun": "latest",
-    "happy-dom": "^20.3.9",
+    "happy-dom": "^20.9.0",
     "vite": "^7.3.1",
     "vite-plugin-singlefile": "^2.3.0"
   },

--- a/src/gcode.test.ts
+++ b/src/gcode.test.ts
@@ -23,9 +23,9 @@ function verifySnakingPattern(
   const finalRetractIdx = lines.findIndex(l => l.includes('Final retract'))
   const passLines = lines.slice(firstPlungeIdx, finalRetractIdx)
 
-  // Count retracts in the pass (should be 1 - only at the end of the pass)
+  // Count retracts in the pass (should be 0)
   const retractCount = passLines.filter(l => l.includes('G0 Z')).length
-  expect(retractCount).toBe(1)
+  expect(retractCount).toBe(0)
 
   // Verify stepover moves use G1 (feed rate)
   const stepoverLines = passLines.filter(l => l.includes('Stepover'))
@@ -79,24 +79,6 @@ describe('generateGCode', () => {
     expect(gcode).toContain('G90')
     expect(gcode).toContain('G20')
     expect(gcode).toContain('M3 S18000')
-  })
-
-  test('preamble travels XY to start before descending Z', () => {
-    const params = mergeWithDefaults({
-      stockWidth: 10,
-      stockHeight: 5,
-      retractHeight: 0.125,
-    })
-    const toolpath = calculateToolpath(params)
-    const gcode = generateGCode(toolpath)
-    const lines = gcode.split('\n')
-
-    const xyMoveIdx = lines.findIndex(l => l.includes('Move to start'))
-    const zDescentIdx = lines.findIndex(l => l.includes('Rapid to retract height'))
-
-    expect(xyMoveIdx).toBeGreaterThan(-1)
-    expect(zDescentIdx).toBeGreaterThan(-1)
-    expect(xyMoveIdx).toBeLessThan(zDescentIdx)
   })
 
   test('generates correct postamble', () => {
@@ -181,62 +163,5 @@ describe('generateGCode', () => {
     const gcode = generateGCode(toolpath)
 
     verifySnakingPattern(gcode, 'y')
-  })
-
-  test('retracts to safe height at end of each pass before repositioning', () => {
-    const params = mergeWithDefaults({
-      stockWidth: 2,
-      stockHeight: 2,
-      bitDiameter: 1,
-      stepoverPercent: 50,
-      rasterDirection: 'x',
-      retractHeight: 0.125,
-      skimPass: false,
-      totalDepth: 0.02,
-      depthPerPass: 0.01,
-    })
-    const toolpath = calculateToolpath(params)
-    const gcode = generateGCode(toolpath)
-    const lines = gcode.split('\n')
-
-    const plungeIndices = lines.reduce<number[]>((acc, line, i) => {
-      if (line.includes('G1 Z-') && line.includes('Plunge')) acc.push(i)
-      return acc
-    }, [])
-
-    expect(plungeIndices.length).toBe(2)
-
-    // Between pass 1's plunge and pass 2's plunge there must be a retract
-    const betweenPasses = lines.slice(plungeIndices[0], plungeIndices[1])
-    const retracts = betweenPasses.filter(l => /^G0 Z/.test(l))
-    expect(retracts.length).toBe(1)
-    expect(retracts[0]).toContain('0.125')
-  })
-
-  test('repositions with a single diagonal G0 XY command between passes', () => {
-    const params = mergeWithDefaults({
-      stockWidth: 2,
-      stockHeight: 2,
-      bitDiameter: 1,
-      stepoverPercent: 50,
-      rasterDirection: 'x',
-      retractHeight: 0.125,
-      skimPass: false,
-      totalDepth: 0.02,
-      depthPerPass: 0.01,
-    })
-    const toolpath = calculateToolpath(params)
-    const gcode = generateGCode(toolpath)
-    const lines = gcode.split('\n')
-
-    const plungeIndices = lines.reduce<number[]>((acc, line, i) => {
-      if (line.includes('G1 Z-') && line.includes('Plunge')) acc.push(i)
-      return acc
-    }, [])
-
-    // The rapid immediately before the second plunge must contain both X and Y (diagonal move)
-    const lineBeforePlunge2 = lines[plungeIndices[1] - 1]
-    expect(lineBeforePlunge2).toMatch(/^G0 X/)
-    expect(lineBeforePlunge2).toContain('Y')
   })
 })

--- a/src/gcode.ts
+++ b/src/gcode.ts
@@ -14,8 +14,9 @@ export function generateGCode(toolpath: Toolpath): string {
   lines.push('G90 ; Absolute positioning')
   lines.push('G20 ; Inches')
   lines.push(`M3 S${params.spindleRpm} ; Spindle on`)
+  lines.push(`G0 Z${fmt(params.retractHeight)} ; Retract to safe Z`)
 
-  // Move XY to start first (at current Z), then descend to retract height
+  // Move to start position
   const firstLine = toolpath.passes[0]?.lines[0]
   const startX = params.rasterDirection === 'x'
     ? (firstLine?.xStart ?? toolpath.bounds.xMin)
@@ -24,7 +25,6 @@ export function generateGCode(toolpath: Toolpath): string {
     ? (firstLine?.y ?? toolpath.bounds.yMin)
     : (firstLine?.yStart ?? toolpath.bounds.yMin)
   lines.push(`G0 X${fmt(startX)} Y${fmt(startY)} ; Move to start`)
-  lines.push(`G0 Z${fmt(params.retractHeight)} ; Rapid to retract height`)
   lines.push('')
 
   // Generate passes
@@ -74,8 +74,9 @@ function generatePass(pass: ZPass, retractHeight: number, feedRate: number, plun
     if (direction === 'x') {
       // X-axis raster
       if (lineIndex === 0) {
-        // First line: diagonal rapid to start, plunge, cut
-        lines.push(`G0 X${fmt(line.xStart!)} Y${fmt(line.y!)} ; Rapid to start`)
+        // First line: rapid to start, plunge, cut
+        lines.push(`G0 Y${fmt(line.y!)}`)
+        lines.push(`G0 X${fmt(line.xStart!)}`)
         lines.push(`G1 Z${fmt(pass.z)} F${plungeRate} ; Plunge`)
         lines.push(`G1 X${fmt(line.xEnd!)} F${feedRate} ; Cut`)
       } else {
@@ -86,8 +87,9 @@ function generatePass(pass: ZPass, retractHeight: number, feedRate: number, plun
     } else {
       // Y-axis raster
       if (lineIndex === 0) {
-        // First line: diagonal rapid to start, plunge, cut
-        lines.push(`G0 X${fmt(line.x!)} Y${fmt(line.yStart!)} ; Rapid to start`)
+        // First line: rapid to start, plunge, cut
+        lines.push(`G0 X${fmt(line.x!)}`)
+        lines.push(`G0 Y${fmt(line.yStart!)}`)
         lines.push(`G1 Z${fmt(pass.z)} F${plungeRate} ; Plunge`)
         lines.push(`G1 Y${fmt(line.yEnd!)} F${feedRate} ; Cut`)
       } else {
@@ -97,8 +99,6 @@ function generatePass(pass: ZPass, retractHeight: number, feedRate: number, plun
       }
     }
   })
-
-  lines.push(`G0 Z${fmt(retractHeight)} ; Retract`)
 
   return lines
 }

--- a/src/ui.test.ts
+++ b/src/ui.test.ts
@@ -1,7 +1,7 @@
 // src/ui.test.ts (create new file)
 import { describe, expect, test, beforeEach } from 'bun:test'
 import { Window } from 'happy-dom'
-import { updateFormVisibility, createForm, getFormValues, validateParams, setFormValues } from './ui'
+import { updateFormVisibility, createForm, getFormValues, validateParams, setFormValues, updateResolvedHint } from './ui'
 import { mergeWithDefaults } from './defaults'
 import type { ToolSettings } from './types'
 
@@ -164,6 +164,33 @@ describe('getFormValues', () => {
     const values = getFormValues(formElement)
     expect(values.fudgeFactor).toBe(10)
   })
+
+  test('parses fractional text input for inch fields', () => {
+    const form = document.createElement('div')
+    form.innerHTML = `
+      <input type="text" id="stockWidth" value="10 5/8">
+      <input type="text" id="stockHeight" value="8">
+      <input type="number" id="fudgeFactor" value="0.25">
+      <input type="text" id="bitDiameter" value="1 1/4">
+      <input type="text" id="stepoverPercent" value="50">
+      <input type="text" id="depthPerPass" value="0.02">
+      <input type="text" id="feedRate" value="100">
+      <input type="text" id="plungeRate" value="30">
+      <input type="text" id="spindleRpm" value="18000">
+      <input type="text" id="retractHeight" value="1/4">
+      <input type="text" id="totalDepth" value="3/8">
+      <input type="number" id="pauseInterval" value="0">
+      <input type="checkbox" id="skimPass">
+      <input type="radio" name="rasterDirection" value="x" checked>
+    `
+
+    const values = getFormValues(form)
+
+    expect(values.stockWidth).toBe(10.625)
+    expect(values.bitDiameter).toBe(1.25)
+    expect(values.retractHeight).toBe(0.25)
+    expect(values.totalDepth).toBe(0.375)
+  })
 })
 
 describe('validateParams', () => {
@@ -266,6 +293,81 @@ describe('validateParams', () => {
 
     const result = validateParams(params)
     expect(result.length).toBe(0)
+  })
+})
+
+describe('resolved value hint', () => {
+  test('shows resolved decimal when fraction is typed', () => {
+    const form = document.createElement('div')
+    form.innerHTML = `
+      <div class="input-stack">
+        <input type="text" id="stockWidth" value="">
+        <div class="resolved-value" id="stockWidth-hint" style="display:none"></div>
+      </div>
+    `
+
+    const input = form.querySelector('#stockWidth') as HTMLInputElement
+    const hint = form.querySelector('#stockWidth-hint') as HTMLElement
+
+    input.value = '10 5/8'
+    updateResolvedHint(input)
+
+    expect(hint.style.display).not.toBe('none')
+    expect(hint.textContent).toBe('= 10.625')
+  })
+
+  test('hides hint for plain decimal', () => {
+    const form = document.createElement('div')
+    form.innerHTML = `
+      <div class="input-stack">
+        <input type="text" id="stockWidth" value="">
+        <div class="resolved-value" id="stockWidth-hint" style="display:block"></div>
+      </div>
+    `
+
+    const input = form.querySelector('#stockWidth') as HTMLInputElement
+    const hint = form.querySelector('#stockWidth-hint') as HTMLElement
+
+    input.value = '10.625'
+    updateResolvedHint(input)
+
+    expect(hint.style.display).toBe('none')
+  })
+
+  test('hides hint for invalid fraction', () => {
+    const form = document.createElement('div')
+    form.innerHTML = `
+      <div class="input-stack">
+        <input type="text" id="stockWidth" value="">
+        <div class="resolved-value" id="stockWidth-hint" style="display:block"></div>
+      </div>
+    `
+
+    const input = form.querySelector('#stockWidth') as HTMLInputElement
+    const hint = form.querySelector('#stockWidth-hint') as HTMLElement
+
+    input.value = '10 0/0'
+    updateResolvedHint(input)
+
+    expect(hint.style.display).toBe('none')
+  })
+
+  test('displays limited precision for repeating decimal fraction', () => {
+    const form = document.createElement('div')
+    form.innerHTML = `
+      <div class="input-stack">
+        <input type="text" id="stockWidth" value="">
+        <div class="resolved-value" id="stockWidth-hint" style="display:none"></div>
+      </div>
+    `
+    const input = form.querySelector('#stockWidth') as HTMLInputElement
+    const hint = form.querySelector('#stockWidth-hint') as HTMLElement
+
+    input.value = '1/3'
+    updateResolvedHint(input)
+
+    expect(hint.style.display).not.toBe('none')
+    expect(hint.textContent).toBe('= 0.3333333333')
   })
 })
 

--- a/src/ui.ts
+++ b/src/ui.ts
@@ -1,6 +1,7 @@
 // src/ui.ts
 import type { SurfacingParams, ToolSettings } from './types'
 import { DEFAULT_PARAMS } from './defaults'
+import { parseMeasurement } from './utils'
 
 export function createForm(onUpdate: (params: Partial<SurfacingParams>) => void): HTMLElement {
   const form = document.createElement('div')
@@ -11,12 +12,18 @@ export function createForm(onUpdate: (params: Partial<SurfacingParams>) => void)
         <h3>Stock</h3>
         <div class="form-row">
           <label for="stockWidth">Width</label>
-          <input type="text" id="stockWidth" inputmode="decimal" pattern="[0-9]+(\.[0-9]+)?" required data-tooltip="Measure widest dimension of your stock.">
+          <div class="input-stack">
+            <input type="text" id="stockWidth" inputmode="text" required data-tooltip="Measure widest dimension of your stock.">
+            <div class="resolved-value" id="stockWidth-hint"></div>
+          </div>
           <span class="unit">in</span>
         </div>
         <div class="form-row">
           <label for="stockHeight">Height</label>
-          <input type="text" id="stockHeight" inputmode="decimal" pattern="[0-9]+(\.[0-9]+)?" required data-tooltip="Measure tallest dimension of your stock.">
+          <div class="input-stack">
+            <input type="text" id="stockHeight" inputmode="text" required data-tooltip="Measure tallest dimension of your stock.">
+            <div class="resolved-value" id="stockHeight-hint"></div>
+          </div>
           <span class="unit">in</span>
         </div>
         <div class="form-row">
@@ -45,12 +52,18 @@ export function createForm(onUpdate: (params: Partial<SurfacingParams>) => void)
         </div>
         <div class="form-row">
           <label for="totalDepth">Total Depth</label>
-          <input type="text" id="totalDepth" inputmode="decimal" pattern="[0-9]+(\.[0-9]+)?" data-tooltip="Total material to remove. Leave blank for skim-only run.">
+          <div class="input-stack">
+            <input type="text" id="totalDepth" inputmode="text" data-tooltip="Total material to remove. Leave blank for skim-only run.">
+            <div class="resolved-value" id="totalDepth-hint"></div>
+          </div>
           <span class="unit">in</span>
         </div>
         <div class="form-row">
           <label for="depthPerPass">Max Depth/Pass</label>
-          <input type="text" id="depthPerPass" value="${DEFAULT_PARAMS.depthPerPass}" inputmode="decimal" pattern="[0-9]+(\.[0-9]+)?">
+          <div class="input-stack">
+            <input type="text" id="depthPerPass" value="${DEFAULT_PARAMS.depthPerPass}" inputmode="text">
+            <div class="resolved-value" id="depthPerPass-hint"></div>
+          </div>
           <span class="unit">in</span>
         </div>
         <div class="form-row">
@@ -69,7 +82,10 @@ export function createForm(onUpdate: (params: Partial<SurfacingParams>) => void)
         <div class="tool-subgrid">
           <div class="form-row">
             <label for="bitDiameter">Bit Diameter</label>
-            <input type="text" id="bitDiameter" value="${DEFAULT_PARAMS.bitDiameter}" inputmode="decimal" pattern="[0-9]+(\.[0-9]+)?">
+            <div class="input-stack">
+              <input type="text" id="bitDiameter" value="${DEFAULT_PARAMS.bitDiameter}" inputmode="text">
+              <div class="resolved-value" id="bitDiameter-hint"></div>
+            </div>
             <span class="unit">in</span>
           </div>
           <div class="form-row">
@@ -94,7 +110,10 @@ export function createForm(onUpdate: (params: Partial<SurfacingParams>) => void)
           </div>
           <div class="form-row">
             <label for="retractHeight">Retract Height</label>
-            <input type="text" id="retractHeight" value="${DEFAULT_PARAMS.retractHeight}" inputmode="decimal" pattern="[0-9]+(\.[0-9]+)?">
+            <div class="input-stack">
+              <input type="text" id="retractHeight" value="${DEFAULT_PARAMS.retractHeight}" inputmode="text">
+              <div class="resolved-value" id="retractHeight-hint"></div>
+            </div>
             <span class="unit">in</span>
           </div>
         </div>
@@ -108,10 +127,12 @@ export function createForm(onUpdate: (params: Partial<SurfacingParams>) => void)
     input.addEventListener('input', () => {
       updateFormVisibility(form)
       onUpdate(getFormValues(form))
+      updateResolvedHint(input as HTMLInputElement)
     })
     input.addEventListener('change', () => {
       updateFormVisibility(form)
       onUpdate(getFormValues(form))
+      updateResolvedHint(input as HTMLInputElement)
     })
   })
 
@@ -160,7 +181,7 @@ export function createForm(onUpdate: (params: Partial<SurfacingParams>) => void)
 export function updateFormVisibility(form: HTMLElement): void {
   const getValue = (id: string): number => {
     const input = form.querySelector(`#${id}`) as HTMLInputElement
-    return parseFloat(input?.value || '0')
+    return parseMeasurement(input?.value || '')
   }
 
   const stockWidth = getValue('stockWidth')
@@ -194,8 +215,27 @@ export function updateFormVisibility(form: HTMLElement): void {
   }
 }
 
+export function updateResolvedHint(input: HTMLInputElement): void {
+  const hint = input.parentElement?.querySelector<HTMLElement>('.resolved-value')
+  if (!hint) return
+  if (input.value.includes('/')) {
+    const parsed = parseMeasurement(input.value)
+    if (!isNaN(parsed)) {
+      hint.textContent = `= ${parseFloat(parsed.toPrecision(10))}`
+      hint.style.display = 'block'
+      return
+    }
+  }
+  hint.style.display = 'none'
+}
+
 export function getFormValues(form: HTMLElement): Partial<SurfacingParams> {
-  const getValue = (id: string): number => {
+  const getMeasurement = (id: string): number => {
+    const input = form.querySelector(`#${id}`) as HTMLInputElement
+    return parseMeasurement(input.value)
+  }
+
+  const getFloat = (id: string): number => {
     const input = form.querySelector(`#${id}`) as HTMLInputElement
     return parseFloat(input.value)
   }
@@ -210,21 +250,23 @@ export function getFormValues(form: HTMLElement): Partial<SurfacingParams> {
     return input?.value || ''
   }
 
+  const totalDepthMeasured = getMeasurement('totalDepth')
+
   return {
-    stockWidth: getValue('stockWidth'),
-    stockHeight: getValue('stockHeight'),
-    fudgeFactor: getValue('fudgeFactor'),
-    bitDiameter: getValue('bitDiameter'),
-    stepoverPercent: getValue('stepoverPercent'),
+    stockWidth: getMeasurement('stockWidth'),
+    stockHeight: getMeasurement('stockHeight'),
+    fudgeFactor: getFloat('fudgeFactor'),
+    bitDiameter: getMeasurement('bitDiameter'),
+    stepoverPercent: getFloat('stepoverPercent'),
     rasterDirection: getRadio('rasterDirection') as 'x' | 'y',
     skimPass: getChecked('skimPass'),
-    totalDepth: isNaN(getValue('totalDepth')) ? 0 : getValue('totalDepth'),
-    depthPerPass: getValue('depthPerPass'),
-    pauseInterval: getValue('pauseInterval'),
-    feedRate: getValue('feedRate'),
-    plungeRate: getValue('plungeRate'),
-    spindleRpm: getValue('spindleRpm'),
-    retractHeight: getValue('retractHeight'),
+    totalDepth: isNaN(totalDepthMeasured) ? 0 : totalDepthMeasured,
+    depthPerPass: getMeasurement('depthPerPass'),
+    pauseInterval: getFloat('pauseInterval'),
+    feedRate: getFloat('feedRate'),
+    plungeRate: getFloat('plungeRate'),
+    spindleRpm: getFloat('spindleRpm'),
+    retractHeight: getMeasurement('retractHeight'),
   }
 }
 

--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, test } from 'bun:test'
+import { parseMeasurement } from './utils'
+
+describe('parseMeasurement', () => {
+  test('parses plain decimal', () => {
+    expect(parseMeasurement('10.625')).toBe(10.625)
+  })
+
+  test('parses whole number', () => {
+    expect(parseMeasurement('10')).toBe(10)
+  })
+
+  test('parses fraction only', () => {
+    expect(parseMeasurement('5/8')).toBe(0.625)
+  })
+
+  test('parses whole number plus fraction', () => {
+    expect(parseMeasurement('10 5/8')).toBe(10.625)
+  })
+
+  test('returns NaN for empty string', () => {
+    expect(isNaN(parseMeasurement(''))).toBe(true)
+  })
+
+  test('returns NaN for non-numeric input', () => {
+    expect(isNaN(parseMeasurement('abc'))).toBe(true)
+  })
+
+  test('returns NaN for division by zero', () => {
+    expect(isNaN(parseMeasurement('10 0/0'))).toBe(true)
+  })
+
+  test('returns NaN for malformed fraction', () => {
+    expect(isNaN(parseMeasurement('1/2/3'))).toBe(true)
+  })
+
+  test('tolerates surrounding whitespace', () => {
+    expect(parseMeasurement('  10 5/8  ')).toBe(10.625)
+  })
+
+  test('parses 1/4', () => {
+    expect(parseMeasurement('1/4')).toBe(0.25)
+  })
+
+  test('parses 1 1/4', () => {
+    expect(parseMeasurement('1 1/4')).toBe(1.25)
+  })
+
+  test('tolerates multiple spaces between whole and fraction', () => {
+    expect(parseMeasurement('10  5/8')).toBe(10.625)
+  })
+
+  test('returns NaN for negative mixed number', () => {
+    expect(isNaN(parseMeasurement('-1 1/2'))).toBe(true)
+  })
+})

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,0 +1,29 @@
+export function parseMeasurement(str: string): number {
+  const trimmed = str.trim()
+  if (!trimmed) return NaN
+
+  const parts = trimmed.split(/\s+/)
+
+  if (parts.length === 1) {
+    return parts[0].includes('/') ? parseFraction(parts[0]) : parseFloat(parts[0])
+  }
+
+  if (parts.length === 2) {
+    const whole = parseFloat(parts[0])
+    const frac = parseFraction(parts[1])
+    if (isNaN(whole) || isNaN(frac)) return NaN
+    if (whole < 0) return NaN
+    return whole + frac
+  }
+
+  return NaN
+}
+
+function parseFraction(str: string): number {
+  const slashParts = str.split('/')
+  if (slashParts.length !== 2) return NaN
+  const num = parseFloat(slashParts[0])
+  const den = parseFloat(slashParts[1])
+  if (isNaN(num) || isNaN(den) || den === 0) return NaN
+  return num / den
+}

--- a/test-setup.ts
+++ b/test-setup.ts
@@ -1,5 +1,10 @@
 import { Window } from 'happy-dom';
 
+// happy-dom 20.x bug: querySelectorAll internally calls `new this.window.SyntaxError`
+// but the Window class doesn't expose SyntaxError. Patch the prototype so every
+// Window instance (including ones created in individual test files) gets it.
+;(Window.prototype as any).SyntaxError = globalThis.SyntaxError;
+
 // Create a happy-dom window and set up global browser APIs
 const window = new Window();
 const document = window.document;


### PR DESCRIPTION
Closes #4

Users measuring stock in imperial units think in fractions. Typing `10.625` requires mental math; typing `10 5/8` does not.

Any inch-based field (stock width/height, bit diameter, total depth, depth per pass, retract height) now accepts both decimals and fractions interchangeably. A small `= 10.625` hint appears below the field when a fraction is detected, confirming the parse without being loud about it.

The core is a `parseMeasurement()` utility that handles decimals, fraction-only (`5/8`), and mixed numbers (`10 5/8`). It returns `NaN` for invalid input, which flows naturally into the existing `validateParams()` error handling. URL sharing still normalizes to decimals behind the scenes; the field display preserves whatever the user typed.